### PR TITLE
Use short-lived GITHUB_TOKEN env variable instead of hard-coded token for composer pull

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -13,6 +13,8 @@ jobs:
 
   build-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
 
@@ -47,4 +49,4 @@ jobs:
         tags: quay.io/pussthecatorg/proxitok:latest
         build-args: |
           release=1
-          GH_TOKEN=${{ secrets.GH_TOKEN }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref:
https://docs.github.com/en/github-ae@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions