### PR TITLE
Removed composer Github Token

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -49,4 +49,3 @@ jobs:
         tags: quay.io/pussthecatorg/proxitok:latest
         build-args: |
           release=1
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM php:8-apache
 WORKDIR /var/www/html
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-ARG GH_TOKEN
 RUN apt update -y && apt upgrade -y \
     && apt install -y --no-install-recommends git libzip-dev \
     && pecl install redis zip \
@@ -11,7 +10,6 @@ RUN apt update -y && apt upgrade -y \
     && chown -R www-data:www-data /cache \
     && rm -rf /var/www/html/* \
     && git clone --depth=1 https://github.com/pablouser1/ProxiTok.git . \
-    && composer config -g github-oauth.github.com "$GH_TOKEN" \
     && composer update \
     && composer install --no-interaction --optimize-autoloader --no-dev \
     && apt autoclean -y \


### PR DESCRIPTION
On older versions of ProxiTok, Composer needed a Github Token to fetch a forked repo from Github. It is no longer needed, the wrapper is downloaded from Packagist.